### PR TITLE
Specify python 3.12.9 for build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,8 +24,7 @@ jobs:
       - name: Install Python and Dependencies
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-          cache: 'pip'
+          python-version: '3.12.9'
       - run: pip install -r requirements.txt
       - run: where.exe python
       - run: quarto install tinytex


### PR DESCRIPTION
This clears up ambiguity in the python version to allow the website to deploy successfully.